### PR TITLE
Args capitalization in docstrings

### DIFF
--- a/JSONGrapher/JSONRecordCreator.py
+++ b/JSONGrapher/JSONRecordCreator.py
@@ -1872,7 +1872,7 @@ class JSONGrapherRecord:
         may be included "_" and double underscore "__" has a special meaning.
         See manual for information about the use of double underscore.
 
-        args:
+        Args:
             datatype (str): The new string to use for the datatype field.
 
         """


### PR DESCRIPTION
From what i can see there was only one place with "args" i replaced that now ther should be no more "args" but rather "Args"